### PR TITLE
Update submitApplePay so that shippingAddress isn't mandatory

### DIFF
--- a/Pod/Classes/RapidAPI+ApplePay.m
+++ b/Pod/Classes/RapidAPI+ApplePay.m
@@ -86,23 +86,16 @@ requiredShippingAddressFields:(PKAddressField)requiredShippingAddressFields
     NSMutableDictionary *paramObject = [NSMutableDictionary new];
     @try {
         Transaction *tran = [[Transaction alloc] init];
+        Customer *customerObj = [[Customer alloc] init];
         
         tran.TransactionType = transactionType;
         tran.Method = method;
         
         if (payment.shippingAddress) {
-            
-            
-            Customer *customerObj = [[Customer alloc] init];
             customerObj.FirstName = (__bridge_transfer NSString*)ABRecordCopyValue(payment.shippingAddress, kABPersonFirstNameProperty);
             customerObj.LastName = (__bridge_transfer NSString*)ABRecordCopyValue(payment.shippingAddress, kABPersonLastNameProperty);
             
-            //customerObj.CompanyName = @"";
-            //customerObj.Phone = @"09 889 0986";
-            //customerObj.Mobile = @"09 889 0986";
-            
             Address *address = [[Address alloc] init];
-            
             ABMultiValueRef addressValues = ABRecordCopyValue(payment.shippingAddress, kABPersonAddressProperty);
             if (addressValues != NULL) {
                 if (ABMultiValueGetCount(addressValues) > 0) {
@@ -132,31 +125,25 @@ requiredShippingAddressFields:(PKAddressField)requiredShippingAddressFields
                 }
                 CFRelease(addressValues);
             }
+            
             customerObj.Address = address;
             
             ShippingDetails *shipping = [[ShippingDetails alloc] init];
             shipping.FirstName = (__bridge_transfer NSString*)ABRecordCopyValue(payment.shippingAddress, kABPersonFirstNameProperty);
             shipping.LastName = (__bridge_transfer NSString*)ABRecordCopyValue(payment.shippingAddress, kABPersonLastNameProperty);
             shipping.ShippingAddress = address;
-            
-            tran.Customer = customerObj;
             tran.ShippingDetails = shipping;
         }
         
+        tran.Customer = customerObj;
         
         NSDictionary *paymentData = [NSJSONSerialization JSONObjectWithData:payment.token.paymentData options:NSJSONReadingAllowFragments error:nil];
         
-        
         NSMutableDictionary *applePayObject = [NSMutableDictionary new];
-        
         [applePayObject setObject:[paymentData objectForKey:@"data"] forKey:@"data"];
-        
         [applePayObject setObject:[paymentData objectForKey:@"header"] forKey:@"header"];
-        
         [applePayObject setObject:[paymentData objectForKey:@"signature"] forKey:@"signature"];
-        
         [applePayObject setObject:[paymentData objectForKey:@"version"] forKey:@"version"];
-        
         
         if (payment.token.paymentInstrumentName)
             [applePayObject setObject:payment.token.paymentInstrumentName forKey:@"PaymentInstrumentName"];

--- a/eWAYPaymentsSDK.podspec
+++ b/eWAYPaymentsSDK.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "eWAYPaymentsSDK"
-  s.version          = "1.1.0"
+  s.version          = "1.1.1"
   s.summary          = "eWAYPaymentsSDK allows eway payment to be performed directly from any compatible iOS device."
   s.description      = "eWAYPaymentsSDK allows eway payment to be performed directly from any compatible iOS device. Apple Pay is supported as well for those device with TouchID. Below are steps needed to be done before using the SDK in your application"
   s.homepage         = "https://www.eway.io/developers/sdk/ios"


### PR DESCRIPTION
Currently, as a consumer of the eWay iOS SDK, when using Apple Pay, you must specify `requiredShippingAddressFields` of your `PKPaymentRequest`, even if your payment doesn't need to capture shipping information. Failure to do so will result in an S9995 error due to the `Customer` property of `Transaction` being nil, which is required.

This change ensures the `Customer` property of `Transaction` is never nil, so that payments without shipping information can be successfully processed.